### PR TITLE
Added method make

### DIFF
--- a/src/main/java/org/javawebstack/injector/Inject.java
+++ b/src/main/java/org/javawebstack/injector/Inject.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.PARAMETER})
 public @interface Inject {
     String value() default "";
 }

--- a/src/main/java/org/javawebstack/injector/Injector.java
+++ b/src/main/java/org/javawebstack/injector/Injector.java
@@ -3,9 +3,9 @@ package org.javawebstack.injector;
 public interface Injector {
 
     <T> T inject(T object);
+    <T> T make(Class<T> clazz);
     <T> T getInstance(Class<T> clazz);
     <T> T getInstance(Class<T> clazz, String name);
     <T> void setInstance(Class<T> clazz, T instance);
     <T> void setInstance(Class<T> clazz, String name, T instance);
-
 }

--- a/src/test/java/unit/org/javawebstack/injector/InjectorTest.java
+++ b/src/test/java/unit/org/javawebstack/injector/InjectorTest.java
@@ -31,6 +31,23 @@ public class InjectorTest {
         assertEquals("Test", test.getB());
     }
 
+    @Test
+    public void testConstructorInjection() {
+        SimpleInjector injector = new SimpleInjector();
+        injector.setInstance(String.class, "Test");
+        injector.setInstance(String.class, "named", "NamedTest");
+        injector.setInstance(Integer.class, 1337);
+
+        Test3 test = injector.make(Test3.class);
+
+        assertEquals(test.getTest(), "Test");
+        assertEquals(test.getNamedTest(), "NamedTest");
+        assertEquals(test.getFieldInjection(), 1337);
+
+        Test4 zArgsConstructorTest = injector.make(Test4.class);
+        assertEquals(zArgsConstructorTest.getTest(), "Test");
+    }
+
     private static class Test1 extends Test2 {
         @Inject
         private String a;
@@ -47,4 +64,37 @@ public class InjectorTest {
         }
     }
 
+    private static class Test3 {
+        private String test;
+        private String namedTest;
+        @Inject
+        private Integer fieldInjection;
+
+        @Inject
+        public Test3(String test, @Inject("named") String namedTest) {
+            this.test = test;
+            this.namedTest = namedTest;
+        }
+
+        public String getTest() {
+            return test;
+        }
+
+        public String getNamedTest() {
+            return namedTest;
+        }
+
+        public Integer getFieldInjection() {
+            return fieldInjection;
+        }
+    }
+
+    private static class Test4 {
+        @Inject
+        private String test;
+
+        public String getTest() {
+            return test;
+        }
+    }
 }


### PR DESCRIPTION
The new method `make` allows construction of classes using constructor injection.
The current behaviour is:
-  If a class has a zero-args constructor it gets constructed
-  But, a constructor with the @Inject annotation has more priority
-  Named injection is also possible, if you annotate your params with the @Inject annotation, see unit tests for details.
-  In addition every field with the @Inject annotation gets injected using the classic `inject` method.

I've added 2 tests which are covering the new functionality.
